### PR TITLE
Fix: GitHub Actions authentication for release workflow

### DIFF
--- a/.github/workflows/1.pipeline.yml
+++ b/.github/workflows/1.pipeline.yml
@@ -48,6 +48,8 @@ jobs:
 
   gradle_release:
     name: Create release
+    permissions:
+      contents: write # Grant write permission for GITHUB_TOKEN to push changes and create releases
     uses: ./.github/workflows/callable.gradle-release.yml
     secrets: inherit
     with:

--- a/.github/workflows/callable.gradle-release.yml
+++ b/.github/workflows/callable.gradle-release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-java@v4
         with:
           distribution: 'corretto'


### PR DESCRIPTION
This PR addresses the GitHub Actions workflow failure related to authentication in the `gradle-release` workflow.

**Changes made:**
- Replaced `secrets.CI_GITHUB_TOKEN` with `secrets.GITHUB_TOKEN` in `.github/workflows/callable.gradle-release.yml`.
- Added `contents: write` permission to the `gradle_release` job in `.github/workflows/1.pipeline.yml` to ensure the `GITHUB_TOKEN` has sufficient permissions for pushing changes and creating releases.

These changes should resolve the `fatal: could not read Username for 'https://github.com': terminal prompts disabled` error during the checkout step.