### PR TITLE
Fix: Override version from tag name for Maven Central releases

### DIFF
--- a/.github/workflows/callable.publish-sonatype.yml
+++ b/.github/workflows/callable.publish-sonatype.yml
@@ -62,6 +62,11 @@ jobs:
         run: |
           echo "Publishing RELEASE version with retry logic..."
           
+          # Extract version from tag name to override gradle.properties
+          TAG_VERSION=${GITHUB_REF#refs/tags/}
+          echo "🏷️ Tag version: $TAG_VERSION"
+          echo "📝 Overriding gradle.properties version with tag version"
+          
           MAX_RETRIES=5
           RETRY_DELAY=60
           ATTEMPT=1
@@ -70,7 +75,7 @@ jobs:
             echo "=== CI Attempt $ATTEMPT of $MAX_RETRIES ==="
             echo "$(date): Starting RELEASE publishing attempt..."
             
-            if ./gradlew publishAndReleaseToMavenCentral --info --stacktrace; then
+            if ./gradlew publishAndReleaseToMavenCentral -Pversion=$TAG_VERSION --info --stacktrace; then
               echo "🎉 SUCCESS! RELEASE publishing completed on attempt $ATTEMPT"
               exit 0
             else


### PR DESCRIPTION
## Problem
When creating tags for releases, the Maven Central publishing workflow was still publishing SNAPSHOT versions instead of release versions. This happened because:

1. The Gradle Release Plugin creates tags on commits that contain SNAPSHOT versions in `gradle.properties`
2. The publishing workflow reads the version from `gradle.properties` instead of using the tag name
3. For example, tag `0.1.3` pointed to a commit with `version=0.1.3-SNAPSHOT` in gradle.properties

## Solution
This PR fixes the issue by:

1. **Extracting version from tag name**: Uses `${GITHUB_REF#refs/tags/}` to get the version from the Git tag
2. **Overriding gradle.properties version**: Passes `-Pversion=$TAG_VERSION` to Gradle to override the SNAPSHOT version
3. **Ensuring release publishing**: Now when publishing from tags, the correct release version is used instead of SNAPSHOT

## Changes
- Modified `.github/workflows/callable.publish-sonatype.yml` to extract tag version and override Gradle version property
- Added logging to show the tag version being used
- Maintains backward compatibility for SNAPSHOT publishing from main branch

## Testing
After merging this PR, creating a new tag should:
1. Extract the version from the tag name (e.g., `0.1.4`)
2. Override the SNAPSHOT version in gradle.properties
3. Publish the release version to Maven Central instead of snapshots repository

Fixes the Maven Central publishing issue where releases were being published as snapshots.